### PR TITLE
Add some error catching around metadata fields

### DIFF
--- a/custom_components/sensor/plex_recently_added.py
+++ b/custom_components/sensor/plex_recently_added.py
@@ -205,9 +205,9 @@ class PlexRecentlyAddedSensor(Entity):
             """Get JSON for each library, combine and sort."""
             for library in sections:
                 sub_sec = plex.get(recently_added.format(
-                    library, self.max_items * 2), headers=headers, timeout=10)
-                try: 
+                    library, self.max_items * 2), headers=headers, timeout=10) 
                     _LOGGER.debug(sub_sec.json()['MediaContainer'])
+                try:
                     self.api_json += sub_sec.json()['MediaContainer']['Metadata']
                 except:
                     _LOGGER.warning('No Metadata field in this library')

--- a/custom_components/sensor/plex_recently_added.py
+++ b/custom_components/sensor/plex_recently_added.py
@@ -206,7 +206,6 @@ class PlexRecentlyAddedSensor(Entity):
             for library in sections:
                 sub_sec = plex.get(recently_added.format(
                     library, self.max_items * 2), headers=headers, timeout=10) 
-                _LOGGER.debug(sub_sec.json()['MediaContainer'])
                 try:
                     self.api_json += sub_sec.json()['MediaContainer']['Metadata']
                 except:

--- a/custom_components/sensor/plex_recently_added.py
+++ b/custom_components/sensor/plex_recently_added.py
@@ -206,7 +206,12 @@ class PlexRecentlyAddedSensor(Entity):
             for library in sections:
                 sub_sec = plex.get(recently_added.format(
                     library, self.max_items * 2), headers=headers, timeout=10)
-                self.api_json += sub_sec.json()['MediaContainer']['Metadata']
+                try: 
+                    _LOGGER.debug(sub_sec.json()['MediaContainer'])
+                    self.api_json += sub_sec.json()['MediaContainer']['Metadata']
+                except:
+                    _LOGGER.warning('No Metadata field in this library')
+                    pass
             self.api_json = sorted(self.api_json, key=lambda i: i['addedAt'],
                                    reverse=True)[:self.max_items]
 

--- a/custom_components/sensor/plex_recently_added.py
+++ b/custom_components/sensor/plex_recently_added.py
@@ -210,7 +210,7 @@ class PlexRecentlyAddedSensor(Entity):
                 try:
                     self.api_json += sub_sec.json()['MediaContainer']['Metadata']
                 except:
-                    _LOGGER.warning('No Metadata field in this library')
+                    _LOGGER.warning('No Metadata field for "{}"'.format(sub_sec.json()['MediaContainer']['librarySectionTitle']))
                     pass
             self.api_json = sorted(self.api_json, key=lambda i: i['addedAt'],
                                    reverse=True)[:self.max_items]

--- a/custom_components/sensor/plex_recently_added.py
+++ b/custom_components/sensor/plex_recently_added.py
@@ -206,7 +206,7 @@ class PlexRecentlyAddedSensor(Entity):
             for library in sections:
                 sub_sec = plex.get(recently_added.format(
                     library, self.max_items * 2), headers=headers, timeout=10) 
-                    _LOGGER.debug(sub_sec.json()['MediaContainer'])
+                _LOGGER.debug(sub_sec.json()['MediaContainer'])
                 try:
                     self.api_json += sub_sec.json()['MediaContainer']['Metadata']
                 except:


### PR DESCRIPTION
Just a try and except to allow things to succeed if there is a missing metadata field... this is a hack, and honestly a .get() is a better case here, but this seems to work for me.