### PR TITLE
Make image download dir configurable and clean up imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This component does not require, nor conflict with, the default Plex components.
 | ssl | false | no | Set to true if you use SSL to access Plex.
 | max | 5 | no | Max number of items to show in sensor.
 | download_images | true | no | Setting this to false will turn off downloading of images, but will require certain Plex settings to work. See below.
+| img_dir | '/custom-lovelace/upcoming-media-card/images/plex/' | no | This option allows you to choose a custom directory to store images in if you enable download_images.
 | ssl_cert | false | no | If you provide your own SSL certificate in Plex's network settings set this to true.
 
 #### By default this addon automatically downloads images from Plex to your /www/custom-lovelace/upcoming-media-card/ directory. The directory is automatically created & only images reported in the upcoming list are downloaded. Images are small in size and are removed automatically when no longer needed. Currently & unfortunately, this may not work on all systems.

--- a/custom_components/sensor/plex_recently_added.py
+++ b/custom_components/sensor/plex_recently_added.py
@@ -37,6 +37,7 @@ CONF_SERVER = 'server_name'
 CONF_SSL_CERT = 'ssl_cert'
 CONF_TOKEN = 'token'
 CONF_MAX = 'max'
+CONF_IMG_CACHE = 'img_dir'
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_SSL, default=False): cv.boolean,
@@ -47,7 +48,8 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DL_IMAGES, default=True): cv.boolean,
     vol.Optional(CONF_HOST, default='localhost'): cv.string,
     vol.Optional(CONF_PORT, default=32400): cv.port,
-    vol.Optional(CONF_IMG_CACHE, default='/custom-lovelace/upcoming-media-card/images/plex/'): cv.string
+    vol.Optional(CONF_IMG_CACHE, 
+                default='/custom-lovelace/upcoming-media-card/images/plex/'): cv.string
 })
 
 

--- a/custom_components/sensor/plex_recently_added.py
+++ b/custom_components/sensor/plex_recently_added.py
@@ -47,6 +47,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     vol.Optional(CONF_DL_IMAGES, default=True): cv.boolean,
     vol.Optional(CONF_HOST, default='localhost'): cv.string,
     vol.Optional(CONF_PORT, default=32400): cv.port,
+    vol.Optional(CONF_IMG_CACHE, default='/custom-lovelace/upcoming-media-card/images/plex/'): cv.string
 })
 
 
@@ -58,7 +59,7 @@ class PlexRecentlyAddedSensor(Entity):
 
     def __init__(self, hass, conf):
         self.conf_dir = str(hass.config.path()) + '/'
-        self._dir = '/custom-lovelace/upcoming-media-card/images/plex/'
+        self._dir = conf.get(CONF_IMG_CACHE)
         self.img = '{0}{1}{2}{3}{4}.jpg'.format(
             self.conf_dir, {}, self._dir, {}, {})
         self._tz = timezone(str(hass.config.time_zone))

--- a/custom_components/sensor/plex_recently_added.py
+++ b/custom_components/sensor/plex_recently_added.py
@@ -7,16 +7,26 @@ https://github.com/custom-components/sensor.plex_recently_added
 https://github.com/custom-cards/upcoming-media-card
 
 """
-import os.path
-import logging
 import json
-import requests
-import voluptuous as vol
-import homeassistant.helpers.config_validation as cv
+import logging
+import math
+import os
+import os.path
+import re
+import time
+import xml.etree.ElementTree as ET
 from datetime import datetime
+from unicodedata import normalize
+from urllib.parse import quote
+
+import requests
+
+import homeassistant.helpers.config_validation as cv
+import voluptuous as vol
 from homeassistant.components.sensor import PLATFORM_SCHEMA
 from homeassistant.const import CONF_HOST, CONF_PORT, CONF_SSL
 from homeassistant.helpers.entity import Entity
+from pytz import timezone, utc
 
 __version__ = '0.1.5'
 
@@ -47,7 +57,6 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
 class PlexRecentlyAddedSensor(Entity):
 
     def __init__(self, hass, conf):
-        from pytz import timezone
         self.conf_dir = str(hass.config.path()) + '/'
         self._dir = '/custom-lovelace/upcoming-media-card/images/plex/'
         self.img = '{0}{1}{2}{3}{4}.jpg'.format(
@@ -85,7 +94,6 @@ class PlexRecentlyAddedSensor(Entity):
 
     @property
     def device_state_attributes(self):
-        import math
         attributes = {}
         if self.change_detected:
             self.card_json = []
@@ -175,8 +183,6 @@ class PlexRecentlyAddedSensor(Entity):
         return attributes
 
     def update(self):
-        import re
-        import os
         plex = requests.Session()
         if not self.cert:
             """Default SSL certificate is for plex.tv not our api server"""
@@ -274,7 +280,6 @@ class PlexRecentlyAddedSensor(Entity):
 
 def image_url(url_elements, cert_check, img):
     """Plex can resize images with a long & partially % encoded url."""
-    from urllib.parse import quote
     ssl, host, local, port, token, self_cert, dl_images = url_elements
     if not cert_check and not self_cert:
         ssl = ''
@@ -298,8 +303,6 @@ def image_url(url_elements, cert_check, img):
 
 def get_server_ip(name, token):
     """With a token and server name we get server's ip, local ip, and port"""
-    import xml.etree.ElementTree as ET
-    from unicodedata import normalize
     plex_tv = requests.get(
         'https://plex.tv/api/servers.xml?X-Plex-Token=' + token, timeout=10)
     plex_xml = ET.fromstring(plex_tv.content)
@@ -312,8 +315,6 @@ def get_server_ip(name, token):
 
 
 def days_since(date, tz):
-    import time
-    from pytz import utc
     date = datetime.utcfromtimestamp(date).isoformat() + 'Z'
     date = datetime.strptime(date, '%Y-%m-%dT%H:%M:%SZ')
     date = str(date.replace(tzinfo=utc).astimezone(tz))[:10]


### PR DESCRIPTION
I dont use the nested structure for my custom additions to hass, so I'd like to be able to use a different path to download and cache my episode images. In the process I noticed imports were peppered all over, so I went ahead and collected them at the top and ran isort to meet pep8