### PR TITLE
Add package.yaml to support indexing on https://haindex.org

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,0 +1,14 @@
+name: Plex Recently Added Component
+description: Home Assistant component to feed Upcoming Media Card with Plex's recently added media
+type: component
+keywords:
+  - plex
+  - recent
+  - recently
+  - playlist
+  - media
+author:
+  name: Ryan Meek
+license: Apache License, Version 2.0
+files:
+  - custom_components/plex_recently_added/sensor.py


### PR DESCRIPTION
Hey there,

I'm currently building a user generated index for Home Assistant custom components and lovelace cards: https://haindex.org
To support the index with some metadata, I've added a package description file to this repository.

It would be great if you accept the pull request and head over to https://haindex.org to get the component indexed. Just log in with your GitHub account and submit the repository URL to be indexed.

Hint: I extracted the author from the contributors. If I made a mistake identifying the original author, let me know :-)

Thanks a lot!

Best, Jens