### PR TITLE
Fix

### DIFF
--- a/custom_components/plex_recently_added/const.py
+++ b/custom_components/plex_recently_added/const.py
@@ -1,6 +1,7 @@
 from typing import Final
 
 DOMAIN: Final = "plex_recently_added"
+TIMEOUT_MINUTES: Final = 10
 
 
 DEFAULT_NAME: Final = 'Plex Recently Added'

--- a/custom_components/plex_recently_added/coordinator.py
+++ b/custom_components/plex_recently_added/coordinator.py
@@ -6,7 +6,7 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryError
 
-from .const import DOMAIN
+from .const import DOMAIN, TIMEOUT_MINUTES
 from .plex_api import (
     PlexApi,
     FailedToLogin,
@@ -23,7 +23,7 @@ class PlexDataCoordinator(DataUpdateCoordinator[Dict[str, Any]]):
             _LOGGER,
             name=DOMAIN,
             update_method=self._async_update_data,
-            update_interval=timedelta(minutes=10),
+            update_interval=timedelta(minutes=TIMEOUT_MINUTES),
         )
     
     async def _async_update_data(self) -> Dict[str, Any]:

--- a/custom_components/plex_recently_added/plex_api.py
+++ b/custom_components/plex_recently_added/plex_api.py
@@ -129,7 +129,7 @@ class PlexApi():
 
         data_out = {}
         for k in data.keys():
-            parsed_data = await parse_data(data[k], self._max, info_url, self._token, identifier, k, self._images_base_url, k == "all")
+            parsed_data = parse_data(self._hass, data[k], self._max, info_url, self._token, identifier, k, self._images_base_url, k == "all")
             
             # Ensure trailer URLs are correctly set for the "all" sensor
             if k == "all":

--- a/custom_components/plex_recently_added/redirect.py
+++ b/custom_components/plex_recently_added/redirect.py
@@ -4,9 +4,6 @@ from aiohttp import web, ClientSession
 import requests
 import os
 
-from .parser import CACHE_FOLDER
-os.makedirs(CACHE_FOLDER, exist_ok=True)
-
 from homeassistant.const import (
     CONF_API_KEY, 
     CONF_NAME, 
@@ -18,23 +15,31 @@ from homeassistant.const import (
 from .const import DOMAIN
 
 class ImagesRedirect(HomeAssistantView):
-    requires_auth = False
-
     def __init__(self, config_entry: ConfigEntry):
         super().__init__()
         self._token = config_entry.data[CONF_API_KEY]
+        self._base_url = f'http{'s' if config_entry.data[CONF_SSL] else ''}://{config_entry.data[CONF_HOST]}:{config_entry.data[CONF_PORT]}'
         self.name = f'{self._token}_Plex_Recently_Added'
         self.url = f'/{config_entry.data[CONF_NAME].lower() + "_" if len(config_entry.data[CONF_NAME]) > 0 else ""}plex_recently_added'
 
     async def get(self, request):
-        filename = request.query.get("filename")
-        if not filename:
-            return web.Response(status=404)
-        file_path = os.path.join(CACHE_FOLDER, filename)
+        metadataId = int(request.query.get("metadata", 0))
+        thumbId = int(request.query.get("thumb", 0))
+        artId = int(request.query.get("art", 0))
+        
+        if metadataId == 0:
+            return web.HTTPNotFound()
+        image_type = "thumb" if thumbId != 0 else "art"
+        image_id = thumbId if thumbId != 0 else artId if artId != 0 else ""
 
-        if not os.path.isfile(file_path):
-            return web.Response(status=404)
+        url = f'{self._base_url}/library/metadata/{metadataId}/{image_type}/{image_id}?X-Plex-Token={self._token}'
 
-        return web.FileResponse(file_path)
+        async with ClientSession() as session:
+            async with session.get(url) as res:
+                if res.ok:
+                    content = await res.read()
+                    return web.Response(body=content, content_type=res.content_type)
+
+                return web.HTTPNotFound()
 
 


### PR DESCRIPTION
- reverted back to not caching the images and redirecting straight to plex
- used "async_sign_path" with the ImageRedirect requiring auth (now it changes every time the sensor updates and has the same timeout (currently 10 minutes), the request without it results in unauthorised response)